### PR TITLE
Create bug.py

### DIFF
--- a/BUG: crosstab(aggfunc='skew') raises IndexError: single positional indexer is out-of-bounds #60768/bug.py
+++ b/BUG: crosstab(aggfunc='skew') raises IndexError: single positional indexer is out-of-bounds #60768/bug.py
@@ -1,0 +1,12 @@
+# Reproducible Example
+import pandas as pd
+
+pd.crosstab(
+    index=["index1","index2"],
+    columns=  ["one", "one"],
+    values=[12,10],
+    normalize=1,
+    margins=True,
+    dropna=True,
+    aggfunc='skew'
+)


### PR DESCRIPTION
Issue Description
The example above gives me the error IndexError: single positional indexer is out-of-bounds.

I don't get this error with aggfunc="sum".

I wonder whether this issue is related to https://github.com/pandas-dev/pandas/issues/60767, where crosstab drops some NaN results.

IndexError                                Traceback (most recent call last)
Cell In[2], line 3
      1 import pandas as pd
----> 3 pd.crosstab(
      4     index=["index1","index2"],
      5     columns=  ["one", "one"],
      6     values=[12,10],
      7     normalize=1,
      8     margins=True,
      9     dropna=True,
     10     aggfunc='skew'
     11 )

File ~/miniconda3/envs/snowpark-python-dev/lib/python3.9/site-packages/pandas/core/reshape/pivot.py:741, in crosstab(index, columns, values, rownames, colnames, aggfunc, margins, margins_name, dropna, normalize)
    739 # Post-process
    740 if normalize is not False:
--> 741     table = _normalize(
    742         table, normalize=normalize, margins=margins, margins_name=margins_name
    743     )
    745 table = table.rename_axis(index=rownames_mapper, axis=0)
    746 table = table.rename_axis(columns=colnames_mapper, axis=1)

File ~/miniconda3/envs/snowpark-python-dev/lib/python3.9/site-packages/pandas/core/reshape/pivot.py:783, in _normalize(table, normalize, margins, margins_name)
    781 table_index = table.index
    782 table_columns = table.columns
--> 783 last_ind_or_col = table.iloc[-1, :].name
    785 # check if margin name is not in (for MI cases) and not equal to last
    786 # index/column and save the column and index margin
    787 if (margins_name not in last_ind_or_col) & (margins_name != last_ind_or_col):

File ~/miniconda3/envs/snowpark-python-dev/lib/python3.9/site-packages/pandas/core/indexing.py:1184, in _LocationIndexer.__getitem__(self, key)
   1182     if self._is_scalar_access(key):
   1183         return self.obj._get_value(*key, takeable=self._takeable)
-> 1184     return self._getitem_tuple(key)
   1185 else:
   1186     # we by definition only have the 0th axis
   1187     axis = self.axis or 0

File ~/miniconda3/envs/snowpark-python-dev/lib/python3.9/site-packages/pandas/core/indexing.py:1690, in _iLocIndexer._getitem_tuple(self, tup)
   1689 def _getitem_tuple(self, tup: tuple):
-> 1690     tup = self._validate_tuple_indexer(tup)
   1691     with suppress(IndexingError):
   1692         return self._getitem_lowerdim(tup)

File ~/miniconda3/envs/snowpark-python-dev/lib/python3.9/site-packages/pandas/core/indexing.py:966, in _LocationIndexer._validate_tuple_indexer(self, key)
    964 for i, k in enumerate(key):
    965     try:
--> 966         self._validate_key(k, i)
    967     except ValueError as err:
    968         raise ValueError(
    969             "Location based indexing can only have "
    970             f"[{self._valid_types}] types"
    971         ) from err

File ~/miniconda3/envs/snowpark-python-dev/lib/python3.9/site-packages/pandas/core/indexing.py:1592, in _iLocIndexer._validate_key(self, key, axis)
   1590     return
   1591 elif is_integer(key):
-> 1592     self._validate_integer(key, axis)
   1593 elif isinstance(key, tuple):
   1594     # a tuple should already have been caught by this point
   1595     # so don't treat a tuple as a valid indexer
   1596     raise IndexingError("Too many indexers")

File ~/miniconda3/envs/snowpark-python-dev/lib/python3.9/site-packages/pandas/core/indexing.py:1685, in _iLocIndexer._validate_integer(self, key, axis)
   1683 len_axis = len(self.obj._get_axis(axis))
   1684 if key >= len_axis or key < -len_axis:
-> 1685     raise IndexError("single positional indexer is out-of-bounds")